### PR TITLE
added sport_id filter for filtering when looking for events on radius

### DIFF
--- a/backend/db/dbAPI.js
+++ b/backend/db/dbAPI.js
@@ -242,7 +242,8 @@ const getEventInfo = (eventId, callback) => {
     .catch(err => callback(err));
 }
 
-const getEventsInRadius = (locationRange, callback) => {
+const getAllEventsInRadius = (latLongRange, callback) => {
+  console.log('calling getAllEventsInRadius')
   db.any(
     `SELECT 
       events.*,
@@ -251,7 +252,21 @@ const getEventsInRadius = (locationRange, callback) => {
     INNER JOIN sports ON events.sport_id = sports.id
     WHERE lat BETWEEN $/minLat/ AND $/maxLat/
     AND long BETWEEN $/minLon/ AND $/maxLon/`
-    , locationRange)
+    , latLongRange)
+    .then((data) => callback(null, data))
+    .catch(err => callback(err));
+}
+
+const getEventsForSportInRadius = (latLongRange, sport_id, callback) => {
+  db.any(
+    `SELECT 
+      events.*,
+      sports.name AS sport_name
+    FROM events
+    INNER JOIN sports ON events.sport_id = sports.id
+    WHERE lat BETWEEN $/minLat/ AND $/maxLat/
+    AND long BETWEEN $/minLon/ AND $/maxLon/ AND events.sport_id = $/sport_id/`
+    , {...latLongRange, sport_id})
     .then((data) => callback(null, data))
     .catch(err => callback(err));
 }
@@ -279,7 +294,8 @@ module.exports = {
   /*- Events Related */
   addEvent: addEvent,
   getEventInfo: getEventInfo,
-  getEventsInRadius: getEventsInRadius,
+  getAllEventsInRadius: getAllEventsInRadius,
+  getEventsForSportInRadius: getEventsForSportInRadius,
   joinEvent: joinEvent,
   leaveEvent: leaveEvent,
   deleteEvent, deleteEvent

--- a/backend/routes/event.js
+++ b/backend/routes/event.js
@@ -87,7 +87,8 @@ router.get('/info/:eventId', loginRequired, (req, res, next) => {
 })
 
 router.get('/radius', loginRequired, (req, res, next) => {
-  const { radius, lat, long } = req.query 
+  const { radius, lat, long, sport_id } = req.query 
+  console.log('sport_id', sport_id)
   //using helper library to get range of lat and long for the given
   //radius
   const locationRange = geo.buildLocationRange(
@@ -95,14 +96,20 @@ router.get('/radius', loginRequired, (req, res, next) => {
     Number.parseFloat(long),
     Number(radius)
   )
-  dbAPI.getEventsInRadius(locationRange, (err, events) => {
+
+  const callback = (err, events) =>{
     if(err) { return next(err) }
     res.status(200)
     res.json({
       events: events,
       msg: 'Events retrieved'
     })
-  })
+  }
+
+  if(!sport_id){
+   return dbAPI.getAllEventsInRadius(locationRange, callback)
+  }
+  dbAPI.getEventsForSportInRadius(locationRange, sport_id, callback)
 })
 
 


### PR DESCRIPTION
Now its possible to request events near you and filter them for a specific sport with the sport_id i.e http://localhost:3100/event/radius?lat=40.758027&long=-73.881801&radius=5&sport_id=1
if calling the route without the sport_id parameters server will respond with all events that are in that radius
@KelvinRod9331 You asked for this, here you go. Please review