### PR TITLE
Events user hosts participated/alejo

### DIFF
--- a/backend/db/dbAPI.js
+++ b/backend/db/dbAPI.js
@@ -323,6 +323,22 @@ const getEventsUserHosts = (userId, callback) => {
     .catch(err => callback(err))
 }
 
+const getEventsUserParticipatedIn = (userId, callback) => {
+  db.any(
+    `SELECT 
+       events.*,
+       users.username AS host_username,
+       sports.name AS sport_name,
+       sports_format.description AS sport_format_description
+     FROM events
+     JOIN sports ON events.sport_id = sports.id
+     JOIN sports_format ON events.sport_format_id = sports_format.id JOIN users ON events.host_id = users.id
+     JOIN players_events ON players_events.event_id = events.id
+     WHERE players_events.player_id = $1`, userId)
+    .then(events => callback(null, events))
+    .catch(err => callback(err))
+}
+
 module.exports = {
   getUserById: getUserById,
   getUserByUsername:getUserByUsername,
@@ -330,6 +346,7 @@ module.exports = {
   getUserInfo: getUserInfo,
   getSportsForUser: getSportsForUser,
   getEventsUserHosts: getEventsUserHosts,
+  getEventsUserParticipatedIn: getEventsUserParticipatedIn,
   getAllUsers: getAllUsers,
   updateUserInfo: updateUserInfo,
   /*- Sports Related */

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -58,7 +58,12 @@ router.get('/sports', loginRequired, (req, res, next) => {
 })
 
 router.get('/events', loginRequired, (req, res, next) => {
- let userId = req.user.id
+  var userId = req.query.user_id
+  //If we dont request a particular userId in the query
+  if(!userId) {
+    //Get the id for the logged in user traveling in the req.user
+    userId = req.user.id  
+  }
   dbAPI.getEventsUserHosts(userId, (err, events) => {
     if(err){return next(err)}
     res.status(200)

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -74,4 +74,21 @@ router.get('/events', loginRequired, (req, res, next) => {
   })
 })
 
+router.get('/events/history', loginRequired, (req, res, next) => {
+  var userId = req.query.user_id
+  //If we dont request a particular userId in the query
+  if(!userId) {
+    //Get the id for the logged in user traveling in the req.user
+    userId = req.user.id  
+  }
+  dbAPI.getEventsUserParticipatedIn(userId, (err, events) => {
+    if(err){return next(err)}
+    res.status(200)
+    res.json({
+      events: events,
+      msg: 'All events hosted by user retrieved'
+    })
+  })
+})
+
 module.exports = router;


### PR DESCRIPTION
Added 
-/user/events when provided with user_id query parameter route responds with all the events the given user HOSTED/ING if query parameter NOT provided then it gets events from the logged in user.

-/user/events/history when provided with user_id query parameter it responds with the events the given user is/has PARTICIPATING/ED in if query parameter NOT provided then it gets events from the logged in user